### PR TITLE
[ONPREM-1862] Set up initial reference Chart with the prometheus-operator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@5.1.1
+
 executors:
   deploy:
     docker:
@@ -18,15 +21,32 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Run linting
+          name: Install dependencies
           command: |
-            echo "TODO: Add linting"
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+            helm dependency build
+      - run:
+          command: helm template --debug .
+          when: always
+      - run:
+          command: helm lint --strict
+          when: always
+      - run:
+          command: ./do kubeconform
+          when: always
+      - notify_failing_main
 
   test:
     executor: deploy
     steps:
       - checkout
-      - run:
-          name: Run tests
-          command: |
-            echo "TODO: Add tests"
+      - run: ./do unit-tests
+
+commands:
+  notify_failing_main:
+    steps:
+      - slack/notify:
+          channel: server-alerts
+          branch_pattern: main
+          event: fail
+          template: basic_fail_1

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 .DS_Store
 /.idea
 /*.iml
+
 /bin
+charts/*.tgz
 /target

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+.github/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+.circleci/
+do
+tests/
+target/
+*.gotmpl

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-operator-crds
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 18.0.0
+digest: sha256:80e1a13c2df80538efe8935ff21d66963eb4db9bcd23a3657b26918e6d939f79
+generated: "2025-02-19T10:00:56.006482464-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: circleci-server-monitoring-stack
+description: A reference Helm chart for setting up a monitoring stack for CircleCI server
+version: 0.1.0
+dependencies:
+  - name: prometheus-operator-crds
+    version: 18.0.0
+    repository: "https://prometheus-community.github.io/helm-charts"

--- a/do
+++ b/do
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_kubeconform="Run helm kubeconform"
+kubeconform() {
+    check-helm
+
+    install-plugin kubeconform https://github.com/jtyr/kubeconform-helm
+
+    helm kubeconform --ignore-missing-schema --verbose --summary --strict "$@" \
+        --schema-location default \
+        --schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json \
+        .
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_unit_tests="Run helm unittest"
+unit-tests() {
+    check-helm
+
+    install-plugin unittest https://github.com/helm-unittest/helm-unittest.git
+
+    helm unittest -f 'tests/**/*_test.yaml' . "$@"
+}
+
+check-helm() {
+    if ! [ -x "$(command -v helm)" ]; then
+        echo 'Helm is required. See: https://helm.sh/docs/intro/install/'
+        exit 1
+    fi
+}
+
+install-plugin() {
+    name="${1}"
+    repo="${2}"
+
+    if ! helm plugin list | grep ${name} >/dev/null; then
+        echo "Installing helm ${name}"
+        helm plugin install "${repo}"
+    fi
+}
+
+help-text-intro() {
+    echo "
+DO
+
+A set of simple repetitive tasks that adds minimally
+to standard tools used to build and test the service.
+(e.g. go and docker)
+"
+}
+
+### START FRAMEWORK ###
+# Do Version 0.0.4
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_self_update="Update the framework from a file.
+
+Usage: $0 self-update FILENAME
+"
+self-update() {
+    local source selfpath pattern
+    source="$1"
+    selfpath="${BASH_SOURCE[0]}"
+    cp "$selfpath" "$selfpath.bak"
+    pattern='/### START FRAMEWORK/,/END FRAMEWORK ###$/'
+    (
+        sed "${pattern}d" "$selfpath"
+        sed -n "${pattern}p" "$source"
+    ) \
+        >"$selfpath.new"
+    mv "$selfpath.new" "$selfpath"
+    chmod --reference="$selfpath.bak" "$selfpath"
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_completion="Print shell completion function for this script.
+
+Usage: $0 completion SHELL"
+completion() {
+    local shell
+    shell="${1-}"
+
+    if [ -z "$shell" ]; then
+        echo "Usage: $0 completion SHELL" 1>&2
+        exit 1
+    fi
+
+    case "$shell" in
+    bash)
+        (
+            echo
+            echo '_dotslashdo_completions() { '
+            # shellcheck disable=SC2016
+            echo '  COMPREPLY=($(compgen -W "$('"$0"' list)" "${COMP_WORDS[1]}"))'
+            echo '}'
+            echo 'complete -F _dotslashdo_completions '"$0"
+        )
+        ;;
+    zsh)
+        cat <<EOF
+_dotslashdo_completions() {
+  local -a subcmds
+  subcmds=()
+  DO_HELP_SKIP_INTRO=1 $0 help | while read line; do
+EOF
+        cat <<'EOF'
+    cmd=$(cut -f1  <<< $line)
+    cmd=$(awk '{$1=$1};1' <<< $cmd)
+
+    desc=$(cut -f2- <<< $line)
+    desc=$(awk '{$1=$1};1' <<< $desc)
+
+    subcmds+=("$cmd:$desc")
+  done
+  _describe 'do' subcmds
+}
+
+compdef _dotslashdo_completions do
+EOF
+        ;;
+    fish)
+        cat <<EOF
+complete -e -c do
+complete -f -c do
+for line in (string split \n (DO_HELP_SKIP_INTRO=1 $0 help))
+EOF
+        cat <<'EOF'
+  set cmd (string split \t $line)
+  complete -c do  -a $cmd[1] -d $cmd[2]
+end
+EOF
+        ;;
+    esac
+}
+
+list() {
+    declare -F | awk '{print $3}'
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_help="Print help text, or detailed help for a task."
+help() {
+    local item
+    item="${1-}"
+    if [ -n "${item}" ]; then
+        local help_name
+        help_name="help_${item//-/_}"
+        echo "${!help_name-}"
+        return
+    fi
+
+    if [ -z "${DO_HELP_SKIP_INTRO-}" ]; then
+        type -t help-text-intro >/dev/null && help-text-intro
+    fi
+    for item in $(list); do
+        local help_name text
+        help_name="help_${item//-/_}"
+        text="${!help_name-}"
+        [ -n "$text" ] && printf "%-30s\t%s\n" "$item" "$(echo "$text" | head -1)"
+    done
+}
+
+case "${1-}" in
+list) list ;;
+"" | "help") help "${2-}" ;;
+*)
+    if ! declare -F "${1}" >/dev/null; then
+        printf "Unknown target: %s\n\n" "${1}"
+        help
+        exit 1
+    else
+        "$@"
+    fi
+    ;;
+esac
+### END FRAMEWORK ###

--- a/templates/prometheus-operator/clusterrole.yaml
+++ b/templates/prometheus-operator/clusterrole.yaml
@@ -1,0 +1,107 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
+  name: prometheus-operator
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - alertmanagers/finalizers
+      - alertmanagers/status
+      - alertmanagerconfigs
+      - prometheuses
+      - prometheuses/finalizers
+      - prometheuses/status
+      - prometheusagents
+      - prometheusagents/finalizers
+      - prometheusagents/status
+      - thanosrulers
+      - thanosrulers/finalizers
+      - thanosrulers/status
+      - scrapeconfigs
+      - servicemonitors
+      - podmonitors
+      - probes
+      - prometheusrules
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/finalizers
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - patch
+      - create
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+      - delete

--- a/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
+  name: prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-operator
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-operator
+    namespace: default

--- a/templates/prometheus-operator/deployment.yaml
+++ b/templates/prometheus-operator/deployment.yaml
@@ -1,0 +1,66 @@
+{{- $repository := .Values.prometheusOperator.image.repository -}}
+{{- $tag := .Values.prometheusOperator.image.tag -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: {{ $tag }}
+  name: prometheus-operator
+spec:
+  replicas: {{ .Values.prometheusOperator.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: prometheus-operator
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: prometheus-operator
+        app.kubernetes.io/version: {{ $tag }}
+    spec:
+      automountServiceAccountToken: true
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      containers:
+        - args:
+            - --kubelet-service=kube-system/kubelet
+            - -prometheus-config-reloader={{ printf "%s-config-reloader:%s" $repository $tag }}
+            - --kubelet-endpoints=true
+            - --kubelet-endpointslice=false
+          env:
+            - name: GOGC
+              value: "30"
+          image: {{ printf "%s:%s" $repository $tag }}
+          name: prometheus-operator
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: prometheus-operator

--- a/templates/prometheus-operator/service.yaml
+++ b/templates/prometheus-operator/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
+  name: prometheus-operator
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator

--- a/templates/prometheus-operator/serviceaccount.yaml
+++ b/templates/prometheus-operator/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
+  name: prometheus-operator

--- a/tests/prometheus-operator/deployment_test.yaml
+++ b/tests/prometheus-operator/deployment_test.yaml
@@ -1,0 +1,25 @@
+suite: test prometheus-operator
+templates:
+  - prometheus-operator/deployment.yaml
+tests:
+  - it: should work
+    set:
+      prometheusOperator.image.repository: myregistry.io/prometheus-operator
+      prometheusOperator.image.tag: 1.2.3
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: prometheus-operator
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: myregistry.io/prometheus-operator:1.2.3
+
+  - it: should set image pull secrets
+    set:
+      global.imagePullSecrets: [regcred]
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: regcred

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,8 @@
+global:
+  imagePullSecrets: []
+
+prometheusOperator:
+  replicas: 1
+  image:
+    repository: quay.io/prometheus-operator/prometheus-operator
+    tag: v0.80.0


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-1862

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

This PR sets up the initial reference chart for monitoring server with the `prometheus-operator` as the first deployment in the stack. As part of this setup, I've added Helm linting and unit tests, which can be run locally and in CI.

In a followup PR, I'll be setting up the Prometheus deployment itself, which will be scraping metrics from the existing Telegraf deployment in server and sending them to Grafana.

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [x] Created and updated tests where applicable

Added unit tests for the initial reference Chart. In addition, I was able to install the Helm chart and have the prometheus-operator deploy successfully:
![Screenshot from 2025-02-19 10-54-54](https://github.com/user-attachments/assets/296e5aa4-81b8-4f2d-b174-9cc79936932f)

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
I'll add documentation in a followup PR where I'll be setting up the deployment of Prometheus itself.