### PR TITLE
[ONPREM-1863] Fix docs check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,9 @@ jobs:
       - run: ./do unit-tests
 
   docs:
-    executor: deploy
+    executor: linux-vm
     steps:
       - checkout
-      - setup_remote_docker
       - run: ./do helm-docs
       - run:
           name: Check for uncommitted helm-docs changes


### PR DESCRIPTION
We run helm-docs via Docker and volume mounts aren't supported with remote Docker; this updates the job to use a machine executor, which seems to resolve the issue

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

https://app.circleci.com/pipelines/github/CircleCI-Public/circleci-server-monitoring-reference/80/workflows/ddd8800c-9cac-45f0-baa3-c84b41869588/jobs/273?invite=true#step-103-0_118

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
