### PR TITLE
[ONPREM-1863] Various updates to the Prometheus deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,8 @@ jobs:
       - run:
           name: Install chart dependencies
           command: |
-            VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
-            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-            helm repo update
-            helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
             helm dependency update
+            helm install prometheus-operator-crds ./charts/prometheus-operator-crds-*.tgz
       - run:
           name: Install Helm chart
           command: helm install circleci-server-monitoring-stack . --wait --timeout=2m -n circleci-server-monitoring
@@ -138,7 +135,7 @@ jobs:
           name: Uninstall Helm chart
           command: |
             helm uninstall circleci-server-monitoring-stack -n circleci-server-monitoring
-            helm uninstall prometheus-operator-crds -n circleci-server-monitoring
+            helm uninstall prometheus-operator-crds
 
 commands:
   notify_failing_main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,12 +80,21 @@ jobs:
             chmod 0700 ~/.kube
             sudo microk8s kubectl config view --raw >"$HOME/.kube/config"
       - run:
-          name: Install Helm chart
+          name: Create namespace
           command: |
             kubectl create ns circleci-server-monitoring
             kubectl config set-context --current --namespace circleci-server-monitoring
+      - run:
+          name: Install chart dependencies
+          command: |
+            VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+            helm repo update
+            helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
             helm dependency update
-            helm install circleci-server-monitoring-stack . --wait --timeout=2m -n circleci-server-monitoring
+      - run:
+          name: Install Helm chart
+          command: helm install circleci-server-monitoring-stack . --wait --timeout=2m -n circleci-server-monitoring
       - run:
           name: Watch Pods
           command: kubectl get pods -w
@@ -127,7 +136,9 @@ jobs:
           when: on_fail
       - run:
           name: Uninstall Helm chart
-          command: helm uninstall circleci-server-monitoring-stack -n circleci-server-monitoring
+          command: |
+            helm uninstall circleci-server-monitoring-stack -n circleci-server-monitoring
+            helm uninstall prometheus-operator-crds -n circleci-server-monitoring
 
 commands:
   notify_failing_main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,13 @@ jobs:
             kubectl create ns circleci-server-monitoring
             kubectl config set-context --current --namespace circleci-server-monitoring
       - run:
-          name: Install chart dependencies
+          name: Install dependencies
           command: |
-            helm dependency update
-            helm install prometheus-operator-crds ./charts/prometheus-operator-crds-*.tgz
+            helm install circleci-server-monitoring-stack . --dependency-update -n circleci-server-monitoring \
+              --set global.enabled=false --set prometheusOperator.installCRDs=true
       - run:
           name: Install Helm chart
-          command: helm install circleci-server-monitoring-stack . --wait --timeout=2m -n circleci-server-monitoring
+          command: helm upgrade --install circleci-server-monitoring-stack . --reset-values --timeout=2m -n circleci-server-monitoring
       - run:
           name: Watch Pods
           command: kubectl get pods -w
@@ -133,9 +133,7 @@ jobs:
           when: on_fail
       - run:
           name: Uninstall Helm chart
-          command: |
-            helm uninstall circleci-server-monitoring-stack -n circleci-server-monitoring
-            helm uninstall prometheus-operator-crds
+          command: helm uninstall circleci-server-monitoring-stack -n circleci-server-monitoring
 
 commands:
   notify_failing_main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,10 @@ jobs:
           background: true
       - run:
          name: Wait for Prometheus
-         command: kubectl wait --for=jsonpath='{.subsets[*].addresses}' endpoints/prometheus --timeout=2m
+         command: kubectl wait --for=jsonpath='{.subsets[*].addresses}' endpoints/server-monitoring-prometheus --timeout=2m
       - run:
           name: Port-forward Prometheus
-          command: kubectl port-forward svc/prometheus 9090
+          command: kubectl port-forward svc/server-monitoring-prometheus 9090
           background: true
       - run:
           name: Check Prometheus status

--- a/Chart.lock
+++ b/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: v5.16.0
-digest: sha256:200e9dcfa6d2eee713111d517432d3ed3c2446849cd04078dcde95c655a59c82
-generated: "2025-02-27T16:10:29.927106947-04:00"
+digest: sha256:b95209cf41d8d93f5a55a3414e1e59f6e900dfd3257438dae00cb11638356bf9
+generated: "2025-02-28T09:54:42.083954446-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: v5.16.0
-digest: sha256:72323fe923bd5387ab13d41f3aeba71d2629115e60955b945ba3bd78ee9b5581
-generated: "2025-02-27T15:32:20.377873828-04:00"
+digest: sha256:200e9dcfa6d2eee713111d517432d3ed3c2446849cd04078dcde95c655a59c82
+generated: "2025-02-27T16:10:29.927106947-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: v5.16.0
-digest: sha256:e5f57ab3beb90eb5c109c38c6d6f0a5bcbdcd103a788eeaa0559ff1745eac784
-generated: "2025-02-26T08:24:44.600682027-04:00"
+digest: sha256:a508194fb3751bbaae0ffcae15440affaee37bbc464aff45d61e231e673a7d60
+generated: "2025-02-27T14:44:00.538261262-04:00"

--- a/Chart.lock
+++ b/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: grafana-operator
   repository: https://grafana.github.io/helm-charts
   version: v5.16.0
-digest: sha256:a508194fb3751bbaae0ffcae15440affaee37bbc464aff45d61e231e673a7d60
-generated: "2025-02-27T14:44:00.538261262-04:00"
+digest: sha256:72323fe923bd5387ab13d41f3aeba71d2629115e60955b945ba3bd78ee9b5581
+generated: "2025-02-27T15:32:20.377873828-04:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,10 +4,12 @@ description: A reference Helm chart for setting up a monitoring stack for Circle
 version: 0.1.0
 dependencies:
   - name: prometheus-operator-crds
-    version: 18.0.1
+    version: 18.0.*
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: prometheusOperatorCRDs.install
+    condition: prometheusOperator.installCRDs
+    alias: prometheusOperator
   - name: grafana-operator
-    version: 5.16.0
+    version: 5.16.*
     repository: "https://grafana.github.io/helm-charts"
     alias: grafanaoperator
+    condition: grafanaoperator.enabled

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,6 +6,7 @@ dependencies:
   - name: prometheus-operator-crds
     version: 18.0.1
     repository: "https://prometheus-community.github.io/helm-charts"
+    condition: prometheusOperatorCRDs.enabled
   - name: grafana-operator
     version: 5.16.0
     repository: "https://grafana.github.io/helm-charts"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - name: prometheus-operator-crds
     version: 18.0.1
     repository: "https://prometheus-community.github.io/helm-charts"
-    condition: prometheusOperatorCRDs.enabled
+    condition: prometheusOperatorCRDs.install
   - name: grafana-operator
     version: 5.16.0
     repository: "https://grafana.github.io/helm-charts"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Then visit http://localhost:9090/targets in your browser. Verify that Telegraf a
 | grafanaoperator.image.tag | string | `"v5.16.0"` | Tag for the Grafana Operator image. |
 | prometheus.image.repository | string | `"quay.io/prometheus/prometheus"` | Image repository for Prometheus. |
 | prometheus.image.tag | string | `"v3.2.0"` | Tag for the Prometheus image. |
+| prometheus.persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes for the persistent volume. |
+| prometheus.persistence.enabled | bool | `false` | Enable persistent storage for Prometheus. |
+| prometheus.persistence.size | string | `"10Gi"` | Size of the persistent volume claim. |
+| prometheus.persistence.storageClass | string | `""` | Storage class for persistent volume provisioner. You can create a custom storage class with a "retain" policy to ensure the persistent volume remains even after the chart is uninstalled. |
 | prometheus.replicas | int | `2` | Number of Prometheus replicas to deploy. |
 | prometheus.serviceMonitor.endpoints[0].port | string | `"prometheus-client"` | Port name for the Prometheus client service. |
 | prometheus.serviceMonitor.selectorLabels | object | `{"app.kubernetes.io/instance":"circleci-server","app.kubernetes.io/name":"telegraf"}` | Labels to select ServiceMonitors for scraping metrics. By default, it's configured to scrape the existing Telegraf deployment in CircleCI server. |
@@ -96,3 +100,4 @@ Then visit http://localhost:9090/targets in your browser. Verify that Telegraf a
 | prometheusOperator.prometheusConfigReloader.image.repository | string | `"quay.io/prometheus-operator/prometheus-config-reloader"` | Image repository for Prometheus Config Reloader. |
 | prometheusOperator.prometheusConfigReloader.image.tag | string | `"v0.80.1"` | Tag for the Prometheus Config Reloader image. |
 | prometheusOperator.replicas | int | `1` | Number of Prometheus Operator replicas to deploy. |
+| prometheusOperatorCRDs.enabled | bool | `true` | Enables the deployment of CRDs required by Prometheus Operator. |

--- a/README.md
+++ b/README.md
@@ -34,19 +34,28 @@ telegraf:
           listen: ":9273"
 ```
 
-### 2. Install the Helm Chart
+### 2. Install the CRDs
+
+Before installing the Prometheus operator, you must first install the Custom Resource Definitions (CRDs) required by it. Follow these steps:
+
+```bash
+$ VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
+$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$ helm repo update
+$ helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
+```
+
+### 3. Install the Helm Chart
 
 Install the Helm chart using the following command. This assumes you are installing it in the same namespace as your CircleCI server:
 
 ```bash
-$ helm install circleci-server-monitoring-stack . --dependency-update --wait -n <your-server-namespace>
+$ helm install circleci-server-monitoring-stack . --dependency-update -n <your-server-namespace>
 ```
-
-> **_NOTE:_**  The `--wait` flag is important to ensure all dependencies are fully installed first.
 
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.
 
-### 3. Verify Prometheus Is Up and Targeting Telegraf
+### 4. Verify Prometheus Is Up and Targeting Telegraf
 To verify that Prometheus is working correctly and targeting Telegraf, use the following command to port-forward Prometheus:
 
 ```bash
@@ -57,7 +66,7 @@ Then visit http://localhost:9090/targets in your browser. Verify that Telegraf a
 
 ![Prometheus UI showing Telegraf target as up](docs/images/prometheus-telegraf-targets.png)
 
-### 4. Next Steps
+### 5. Next Steps
 
 [TODO: Add next steps]
 
@@ -100,4 +109,4 @@ Then visit http://localhost:9090/targets in your browser. Verify that Telegraf a
 | prometheusOperator.prometheusConfigReloader.image.repository | string | `"quay.io/prometheus-operator/prometheus-config-reloader"` | Image repository for Prometheus Config Reloader. |
 | prometheusOperator.prometheusConfigReloader.image.tag | string | `"v0.80.1"` | Tag for the Prometheus Config Reloader image. |
 | prometheusOperator.replicas | int | `1` | Number of Prometheus Operator replicas to deploy. |
-| prometheusOperatorCRDs.enabled | bool | `true` | Enables the deployment of CRDs required by Prometheus Operator. |
+| prometheusOperatorCRDs.install | bool | `false` |  |

--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ telegraf:
 Before installing the Prometheus operator, you must first install the Custom Resource Definitions (CRDs) required by it. Follow these steps:
 
 ```bash
-$ VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
-$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-$ helm repo update
-$ helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
+$ helm dependency update
+$ helm install prometheus-operator-crds ./charts/prometheus-operator-crds-*.tgz
 ```
 
 ### 3. Install the Helm Chart
@@ -50,7 +48,7 @@ $ helm install prometheus-operator-crds prometheus-community/prometheus-operator
 Install the Helm chart using the following command. This assumes you are installing it in the same namespace as your CircleCI server:
 
 ```bash
-$ helm install circleci-server-monitoring-stack . --dependency-update -n <your-server-namespace>
+$ helm install circleci-server-monitoring-stack . -n <your-server-namespace>
 ```
 
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -28,21 +28,20 @@ telegraf:
           listen: ":9273"
 ```
 
-### 2. Install the CRDs
+### 2. Install Dependencies
 
-Before installing the Prometheus operator, you must first install the Custom Resource Definitions (CRDs) required by it. Follow these steps:
+Before installing the full chart, you must first install the dependency subcharts, including the Prometheus Custom Resource Definitions (CRDs) and the Grafana operator chart. This assumes you are installing it in the same namespace as your CircleCI server installation:
 
 ```bash
-$ helm dependency update
-$ helm install prometheus-operator-crds ./charts/prometheus-operator-crds-*.tgz
+$ helm install {{ template "chart.name" . }} . --dependency-update --set global.enabled=false --set prometheusOperator.installCRDs=true -n <your-server-namespace>
 ```
 
 ### 3. Install the Helm Chart
 
-Install the Helm chart using the following command. This assumes you are installing it in the same namespace as your CircleCI server:
+Next, install the Helm chart using the following command:
 
 ```bash
-$ helm install {{ template "chart.name" . }} . -n <your-server-namespace>
+$ helm upgrade --install {{ template "chart.name" . }} . --reset-values -n <your-server-namespace>
 ```
 
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -33,10 +33,8 @@ telegraf:
 Before installing the Prometheus operator, you must first install the Custom Resource Definitions (CRDs) required by it. Follow these steps:
 
 ```bash
-$ VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
-$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-$ helm repo update
-$ helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
+$ helm dependency update
+$ helm install prometheus-operator-crds ./charts/prometheus-operator-crds-*.tgz
 ```
 
 ### 3. Install the Helm Chart
@@ -44,7 +42,7 @@ $ helm install prometheus-operator-crds prometheus-community/prometheus-operator
 Install the Helm chart using the following command. This assumes you are installing it in the same namespace as your CircleCI server:
 
 ```bash
-$ helm install {{ template "chart.name" . }} . --dependency-update -n <your-server-namespace>
+$ helm install {{ template "chart.name" . }} . -n <your-server-namespace>
 ```
 
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -28,19 +28,28 @@ telegraf:
           listen: ":9273"
 ```
 
-### 2. Install the Helm Chart
+### 2. Install the CRDs
+
+Before installing the Prometheus operator, you must first install the Custom Resource Definitions (CRDs) required by it. Follow these steps:
+
+```bash
+$ VERSION=$(helm dependency list | grep prometheus-operator-crds | cut -f 2)
+$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$ helm repo update
+$ helm install prometheus-operator-crds prometheus-community/prometheus-operator-crds --version "${VERSION}"
+```
+
+### 3. Install the Helm Chart
 
 Install the Helm chart using the following command. This assumes you are installing it in the same namespace as your CircleCI server:
 
 ```bash
-$ helm install {{ template "chart.name" . }} . --dependency-update --wait -n <your-server-namespace>
+$ helm install {{ template "chart.name" . }} . --dependency-update -n <your-server-namespace>
 ```
-
-> **_NOTE:_**  The `--wait` flag is important to ensure all dependencies are fully installed first.
 
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.
 
-### 3. Verify Prometheus Is Up and Targeting Telegraf
+### 4. Verify Prometheus Is Up and Targeting Telegraf
 To verify that Prometheus is working correctly and targeting Telegraf, use the following command to port-forward Prometheus:
 
 ```bash
@@ -51,7 +60,7 @@ Then visit http://localhost:9090/targets in your browser. Verify that Telegraf a
 
 ![Prometheus UI showing Telegraf target as up](docs/images/prometheus-telegraf-targets.png)
 
-### 4. Next Steps
+### 5. Next Steps
 
 [TODO: Add next steps]
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -9,3 +9,30 @@ Return the fully qualified name of a resource based on the chart's full name, na
 {{- printf "%s-%s" $name .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Compute if prometheusOperator is enabled.
+*/}}
+{{- define "prometheusOperator.enabled" -}}
+{{- $_ := set . "prometheusOperatorEnabled" (or
+  (eq (.Values.prometheusOperator.enabled | toString) "true")
+  (and (eq (.Values.prometheusOperator.enabled | toString) "-") (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}
+
+{{/*
+Compute if prometheus is enabled.
+*/}}
+{{- define "prometheus.enabled" -}}
+{{- $_ := set . "prometheusEnabled" (or
+  (eq (.Values.prometheus.enabled | toString) "true")
+  (and (eq (.Values.prometheus.enabled | toString) "-") (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}
+
+{{/*
+Compute if grafana is enabled.
+*/}}
+{{- define "grafana.enabled" -}}
+{{- $_ := set . "grafanaEnabled" (or
+  (eq (.Values.grafana.enabled | toString) "true")
+  (and (eq (.Values.grafana.enabled | toString) "-") (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}

--- a/templates/grafana/dashboards.yaml
+++ b/templates/grafana/dashboards.yaml
@@ -1,3 +1,6 @@
+{{- include "grafana.enabled" . -}}
+{{- if .grafanaEnabled }}
+
 {{- $name := include "server-monitoring.fullname" . -}}
 {{- range .Values.grafana.dashboards }}
 apiVersion: grafana.integreatly.org/v1beta1
@@ -12,4 +15,6 @@ spec:
   json: |
     {{ .json | nindent 4 }}
 ---
+{{- end }}
+
 {{- end }}

--- a/templates/grafana/datasource.yaml
+++ b/templates/grafana/datasource.yaml
@@ -11,7 +11,7 @@ spec:
       timeInterval: {{ .Values.grafana.datasource.jsonData.timeInterval }}
       tlsSkipVerify: true
     name: Prometheus
-    url: http://prometheus:9090
+    url: http://{{ $name }}-prometheus:9090
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/templates/grafana/datasource.yaml
+++ b/templates/grafana/datasource.yaml
@@ -1,3 +1,5 @@
+{{- include "grafana.enabled" . -}}
+{{- if .grafanaEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
@@ -15,3 +17,4 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
+{{- end }}

--- a/templates/grafana/grafana.yaml
+++ b/templates/grafana/grafana.yaml
@@ -1,3 +1,5 @@
+{{- include "grafana.enabled" . -}}
+{{- if .grafanaEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 {{- $imagePullSecrets := .Values.global.imagePullSecrets -}}
 {{- with .Values.grafana }}
@@ -67,4 +69,5 @@ spec:
       mode: "console"
     auth:
       disable_login_form: "false"
+{{- end }}
 {{- end }}

--- a/templates/grafana/pvc.yaml
+++ b/templates/grafana/pvc.yaml
@@ -1,3 +1,5 @@
+{{- include "grafana.enabled" . -}}
+{{- if .grafanaEnabled }}
 {{- with .Values.grafana.persistence }}
 {{- if .enabled }}
 {{- $name := include "server-monitoring.fullname" $ -}}
@@ -16,5 +18,6 @@ spec:
   {{- if .storageClass }}
   storageClassName: {{ .storageClass | quote }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/grafana/secret.yaml
+++ b/templates/grafana/secret.yaml
@@ -1,3 +1,5 @@
+{{- include "grafana.enabled" . -}}
+{{- if .grafanaEnabled }}
 {{- $name := include "server-monitoring.fullname" $ -}}
 {{- with .Values.grafana.credentials }}
 {{- if not .existingSecretName }}
@@ -9,5 +11,6 @@ type: Opaque
 stringData:
   GF_SECURITY_ADMIN_USER: {{ .adminUser }}
   GF_SECURITY_ADMIN_PASSWORD: {{ .adminPassword }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/prometheus-operator/clusterrole.yaml
+++ b/templates/prometheus-operator/clusterrole.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheusOperator.enabled" . -}}
+{{- if .prometheusOperatorEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -107,3 +109,4 @@ rules:
       - create
       - update
       - delete
+{{- end }}

--- a/templates/prometheus-operator/clusterrole.yaml
+++ b/templates/prometheus-operator/clusterrole.yaml
@@ -1,3 +1,5 @@
+{{- $name := include "server-monitoring.fullname" . -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -5,7 +7,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
-  name: prometheus-operator
+  name: {{ $name }}-prometheus-operator
 rules:
   - apiGroups:
       - monitoring.coreos.com

--- a/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheusOperator.enabled" . -}}
+{{- if .prometheusOperatorEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,3 +18,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ $name }}-prometheus-operator
     namespace:  {{ .Release.Namespace }}
+{{- end }}

--- a/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/templates/prometheus-operator/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+{{- $name := include "server-monitoring.fullname" . -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -5,12 +7,12 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
-  name: prometheus-operator
+  name: {{ $name }}-prometheus-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus-operator
+  name: {{ $name }}-prometheus-operator
 subjects:
   - kind: ServiceAccount
-    name: prometheus-operator
+    name: {{ $name }}-prometheus-operator
     namespace:  {{ .Release.Namespace }}

--- a/templates/prometheus-operator/deployment.yaml
+++ b/templates/prometheus-operator/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $name := include "server-monitoring.fullname" . -}}
 {{- $repository := .Values.prometheusOperator.image.repository -}}
 {{- $tag := .Values.prometheusOperator.image.tag -}}
 
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/version: {{ $tag }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-  name: prometheus-operator
+  name: {{ $name}}-prometheus-operator
 spec:
   replicas: {{ .Values.prometheusOperator.replicas }}
   selector:
@@ -67,4 +68,4 @@ spec:
         runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: prometheus-operator
+      serviceAccountName: {{ $name}}-prometheus-operator

--- a/templates/prometheus-operator/deployment.yaml
+++ b/templates/prometheus-operator/deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ $tag }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
   name: {{ $name}}-prometheus-operator
 spec:
   replicas: {{ .Values.prometheusOperator.replicas }}

--- a/templates/prometheus-operator/deployment.yaml
+++ b/templates/prometheus-operator/deployment.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheusOperator.enabled" . -}}
+{{- if .prometheusOperatorEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 {{- $repository := .Values.prometheusOperator.image.repository -}}
 {{- $tag := .Values.prometheusOperator.image.tag -}}
@@ -67,3 +69,4 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: {{ $name}}-prometheus-operator
+{{- end }}

--- a/templates/prometheus-operator/service.yaml
+++ b/templates/prometheus-operator/service.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheusOperator.enabled" . -}}
+{{- if .prometheusOperatorEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +17,4 @@ spec:
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
+{{- end }}

--- a/templates/prometheus-operator/service.yaml
+++ b/templates/prometheus-operator/service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
-  name: prometheus-operator
+  name: {{ include "server-monitoring.fullname" . }}-prometheus-operator
 spec:
   clusterIP: None
   ports:

--- a/templates/prometheus-operator/serviceaccount.yaml
+++ b/templates/prometheus-operator/serviceaccount.yaml
@@ -6,4 +6,4 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
-  name: prometheus-operator
+  name: {{ include "server-monitoring.fullname" . }}-prometheus-operator

--- a/templates/prometheus-operator/serviceaccount.yaml
+++ b/templates/prometheus-operator/serviceaccount.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheusOperator.enabled" . -}}
+{{- if .prometheusOperatorEnabled }}
 apiVersion: v1
 automountServiceAccountToken: false
 kind: ServiceAccount
@@ -7,3 +9,4 @@ metadata:
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/version: {{ .Values.prometheusOperator.image.tag }}
   name: {{ include "server-monitoring.fullname" . }}-prometheus-operator
+{{- end }}

--- a/templates/prometheus/clusterrole.yaml
+++ b/templates/prometheus/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus
+  name: {{ include "server-monitoring.fullname" . }}-prometheus
 rules:
   - apiGroups: [""]
     resources:

--- a/templates/prometheus/clusterrole.yaml
+++ b/templates/prometheus/clusterrole.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,3 +13,4 @@ rules:
     verbs: ["get", "list", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
+{{- end }}

--- a/templates/prometheus/clusterrolebinding.yaml
+++ b/templates/prometheus/clusterrolebinding.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +12,4 @@ subjects:
   - kind: ServiceAccount
     name: prometheus
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/prometheus/clusterrolebinding.yaml
+++ b/templates/prometheus/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus
+  name: {{ include "server-monitoring.fullname" . }}-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/prometheus/prometheus.yaml
+++ b/templates/prometheus/prometheus.yaml
@@ -31,3 +31,17 @@ spec:
   serviceAccountName: {{ $name }}-prometheus
   version: {{ $tag }}
   serviceMonitorSelector: {}
+  {{- with .Values.prometheus.persistence }}
+  {{- if .enabled }}
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: {{ .accessModes | toJson }}
+        resources:
+          requests:
+            storage: {{ .size }}
+        {{- if .storageClass }}
+        storageClassName: {{ .storageClass }}
+        {{- end }}
+  {{- end }}
+  {{- end }}

--- a/templates/prometheus/prometheus.yaml
+++ b/templates/prometheus/prometheus.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 {{- $repository := .Values.prometheus.image.repository -}}
 {{- $tag := .Values.prometheus.image.tag -}}
@@ -43,3 +45,5 @@ spec:
         {{- end }}
   {{- end }}
   {{- end }}
+
+{{- end }}

--- a/templates/prometheus/prometheus.yaml
+++ b/templates/prometheus/prometheus.yaml
@@ -1,12 +1,13 @@
+{{- $name := include "server-monitoring.fullname" . -}}
 {{- $repository := .Values.prometheus.image.repository -}}
 {{- $tag := .Values.prometheus.image.tag -}}
 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
-  name: prometheus
+  name: {{ $name }}-prometheus
   labels:
-    app: prometheus
+    app: {{ $name }}-prometheus
   annotations:
     "helm.sh/hook": post-install,post-upgrade
 spec:
@@ -27,6 +28,6 @@ spec:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
-  serviceAccountName: prometheus
+  serviceAccountName: {{ $name }}-prometheus
   version: {{ $tag }}
   serviceMonitorSelector: {}

--- a/templates/prometheus/prometheus.yaml
+++ b/templates/prometheus/prometheus.yaml
@@ -8,8 +8,6 @@ metadata:
   name: {{ $name }}-prometheus
   labels:
     app: {{ $name }}-prometheus
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
 spec:
   {{- with .Values.global.imagePullSecrets }}
   imagePullSecrets:

--- a/templates/prometheus/service.yaml
+++ b/templates/prometheus/service.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 
 apiVersion: v1
@@ -14,3 +16,5 @@ spec:
   selector:
     app.kubernetes.io/name: prometheus
   sessionAffinity: ClientIP
+
+{{- end }}

--- a/templates/prometheus/service.yaml
+++ b/templates/prometheus/service.yaml
@@ -1,9 +1,11 @@
+{{- $name := include "server-monitoring.fullname" . -}}
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus
+  name: {{ $name }}-prometheus
   labels:
-    app: prometheus
+    app: {{ $name }}-prometheus
 spec:
   ports:
     - name: web

--- a/templates/prometheus/serviceaccount.yaml
+++ b/templates/prometheus/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus
+  name: {{ include "server-monitoring.fullname" . }}-prometheus

--- a/templates/prometheus/serviceaccount.yaml
+++ b/templates/prometheus/serviceaccount.yaml
@@ -1,4 +1,7 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "server-monitoring.fullname" . }}-prometheus
+{{- end }}

--- a/templates/prometheus/servicemonitor.yaml
+++ b/templates/prometheus/servicemonitor.yaml
@@ -1,3 +1,5 @@
+{{- include "prometheus.enabled" . -}}
+{{- if .prometheusEnabled }}
 {{- $name := include "server-monitoring.fullname" . -}}
 
 {{- with .Values.prometheus.serviceMonitor }}
@@ -18,4 +20,5 @@ spec:
 {{- end }}
   endpoints:
 {{ toYaml .endpoints | indent 4 }}
+{{- end }}
 {{- end }}

--- a/templates/prometheus/servicemonitor.yaml
+++ b/templates/prometheus/servicemonitor.yaml
@@ -1,10 +1,12 @@
+{{- $name := include "server-monitoring.fullname" . -}}
+
 {{- with .Values.prometheus.serviceMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: prometheus
+  name: {{ $name }}-prometheus
   labels:
-    app: prometheus
+    app: {{ $name }}-prometheus
   annotations:
     "helm.sh/hook": post-install,post-upgrade
 spec:

--- a/templates/prometheus/servicemonitor.yaml
+++ b/templates/prometheus/servicemonitor.yaml
@@ -7,8 +7,6 @@ metadata:
   name: {{ $name }}-prometheus
   labels:
     app: {{ $name }}-prometheus
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
 spec:
   selector:
     matchLabels:

--- a/tests/grafana/datasource_test.yaml
+++ b/tests/grafana/datasource_test.yaml
@@ -29,7 +29,7 @@ tests:
           value: Prometheus
       - equal:
           path: spec.datasource.url
-          value: http://prometheus:9090
+          value: http://server-monitoring-prometheus:9090
       - equal:
           path: spec.instanceSelector.matchLabels.dashboards
           value: grafana

--- a/tests/kubeconform/globally-disabled-values.yaml
+++ b/tests/kubeconform/globally-disabled-values.yaml
@@ -1,0 +1,2 @@
+global:
+  enabled: false

--- a/tests/kubeconform/grafana-pvc-values.yaml
+++ b/tests/kubeconform/grafana-pvc-values.yaml
@@ -1,4 +1,0 @@
-grafana:
-  persistence:
-    enabled: true
-    storageClass: "custom"

--- a/tests/kubeconform/pvc-values.yaml
+++ b/tests/kubeconform/pvc-values.yaml
@@ -1,0 +1,9 @@
+prometheus:
+  persistence:
+    enabled: true
+    storageClass: "custom-storage"
+
+grafana:
+  persistence:
+    enabled: true
+    storageClass: "custom-storage"

--- a/tests/prometheus/prometheus_test.yaml
+++ b/tests/prometheus/prometheus_test.yaml
@@ -27,3 +27,12 @@ tests:
       - equal:
           path: spec.imagePullSecrets[0].name
           value: regcred
+
+  - it: should enable persistence
+    set:
+      prometheus.persistence.enabled: true
+      prometheus.persistence.size: 11Gi
+    asserts:
+      - equal:
+          path: spec.storage.volumeClaimTemplate.spec.resources.requests.storage
+          value: 11Gi

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,10 @@ global:
   # -- Override the full name for resources
   fullnameOverride: "server-monitoring"
 
+prometheusOperatorCRDs:
+  # -- Enables the deployment of CRDs required by Prometheus Operator.
+  enabled: true
+
 prometheusOperator:
   # -- Number of Prometheus Operator replicas to deploy.
   replicas: 1
@@ -42,6 +46,18 @@ prometheus:
     endpoints:
       - # -- Port name for the Prometheus client service.
         port: prometheus-client
+  persistence:
+    # -- Enable persistent storage for Prometheus.
+    enabled: false
+    # -- Access modes for the persistent volume.
+    accessModes:
+      - ReadWriteOnce
+    # -- Size of the persistent volume claim.
+    size: 10Gi
+    # -- Storage class for persistent volume provisioner. You can create a custom
+    # storage class with a "retain" policy to ensure the persistent volume
+    # remains even after the chart is uninstalled.
+    storageClass: ""
 
 # -- Full values for the Grafana Operator chart can be obtained at:
 # https://github.com/grafana/grafana-operator/blob/master/deploy/helm/grafana-operator/values.yaml

--- a/values.yaml
+++ b/values.yaml
@@ -7,8 +7,7 @@ global:
   fullnameOverride: "server-monitoring"
 
 prometheusOperatorCRDs:
-  # -- Enables the deployment of CRDs required by Prometheus Operator.
-  enabled: true
+  install: false
 
 prometheusOperator:
   # -- Number of Prometheus Operator replicas to deploy.

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,5 @@
 global:
+  enabled: true
   # -- List of image pull secrets to be used across the deployment
   imagePullSecrets: []
   # -- Override the release name
@@ -6,10 +7,12 @@ global:
   # -- Override the full name for resources
   fullnameOverride: "server-monitoring"
 
-prometheusOperatorCRDs:
-  install: false
-
 prometheusOperator:
+  enabled: "-"
+  installCRDs: false
+  crds:
+    annotations:
+      "helm.sh/resource-policy": "keep"
   # -- Number of Prometheus Operator replicas to deploy.
   replicas: 1
   image:
@@ -25,6 +28,7 @@ prometheusOperator:
       tag: v0.80.1
 
 prometheus:
+  enabled: "-"
   # -- Number of Prometheus replicas to deploy.
   replicas: 2
   image:
@@ -77,6 +81,7 @@ grafanaoperator:
       type: ClusterIP
 
 grafana:
+  enabled: "-"
   # -- Number of Grafana replicas to deploy.
   replicas: 2
   image:


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

This PR introduces a few changes to the Prometheus deployment:
- The release name is now templated on all Prometheus-related resources
- Persistence storage can be optionally enabled for Prometheus
- Updated the installation guide to have the prometheus-operator CRDs be installed first. The subchart has the CRDs under a `templates` directory instead of a `crds` directory. This means Helm will template the CRDs at the same time as the resources requiring them, which will fail. We could work around this with Helm hooks, but that removes them from the release and prevents Helm from uninstalling them.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
