### PR TITLE
[ONPREM-2071] Drop default ServiceMonitor labels

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -24,6 +24,7 @@
 .vscode/
 
 .circleci/
+bin/
 do
 docs/
 renovate.json5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: server-monitoring-stack
 description: A reference Helm chart for setting up a monitoring stack for CircleCI server
-version: 0.1.0-alpha.1
+version: 0.1.0-alpha.2
 dependencies:
   - name: prometheus-operator-crds
     version: 18.0.*

--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ grafana:
 | prometheus.persistence.size | string | `"10Gi"` | Size of the persistent volume claim. |
 | prometheus.persistence.storageClass | string | `""` | Storage class for persistent volume provisioner. You can create a custom storage class with a "retain" policy to ensure the persistent volume remains even after the chart is uninstalled. |
 | prometheus.replicas | int | `2` | Number of Prometheus replicas to deploy. |
+| prometheus.serviceMonitor.endpoints[0].metricRelabelings[0].action | string | `"labeldrop"` |  |
+| prometheus.serviceMonitor.endpoints[0].metricRelabelings[0].regex | string | `"instance"` |  |
 | prometheus.serviceMonitor.endpoints[0].port | string | `"prometheus-client"` | Port name for the Prometheus client service. |
+| prometheus.serviceMonitor.endpoints[0].relabelings[0].action | string | `"labeldrop"` |  |
+| prometheus.serviceMonitor.endpoints[0].relabelings[0].regex | string | `"(container|endpoint|namespace|pod|service)"` |  |
 | prometheus.serviceMonitor.selectorLabels | object | `{"app.kubernetes.io/instance":"circleci-server","app.kubernetes.io/name":"telegraf"}` | Labels to select ServiceMonitors for scraping metrics. By default, it's configured to scrape the existing Telegraf deployment in CircleCI server. |
 | prometheus.serviceMonitor.selectorNamespaces | list | `[]` | Namespaces to look for ServiceMonitor objects. Set this if the CircleCI server monitoring stack is deploying in a different namespace than the actual CircleCI server installation. |
 | prometheusOperator.crds.annotations."helm.sh/resource-policy" | string | `"keep"` |  |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is currently under active development and is not yet a supported
 
 A reference Helm chart for setting up a monitoring stack for CircleCI server
 
-![Version: 0.1.0-alpha.1](https://img.shields.io/badge/Version-0.1.0--alpha.1-informational?style=flat-square)
+![Version: 0.1.0-alpha.2](https://img.shields.io/badge/Version-0.1.0--alpha.2-informational?style=flat-square)
 
 ## Installing the Monitoring Stack
 
@@ -47,7 +47,7 @@ $ helm repo update
 Before installing the full chart, you must first install the dependency subcharts, including the Prometheus Custom Resource Definitions (CRDs) and the Grafana operator chart. This assumes you are installing it in the same namespace as your CircleCI server installation:
 
 ```bash
-$ helm install server-monitoring-stack server-monitoring-stack/server-monitoring-stack --set global.enabled=false --set prometheusOperator.installCRDs=true --version 0.1.0-alpha.1 -n <your-server-namespace>
+$ helm install server-monitoring-stack server-monitoring-stack/server-monitoring-stack --set global.enabled=false --set prometheusOperator.installCRDs=true --version 0.1.0-alpha.2 -n <your-server-namespace>
 ```
 > **_NOTE:_**  It's possible to install the monitoring stack in a different namespace than the CircleCI server installation. If you do so, set the `prometheus.serviceMonitor.selectorNamespaces` value with the target namespace.
 
@@ -56,7 +56,7 @@ $ helm install server-monitoring-stack server-monitoring-stack/server-monitoring
 Next, install the Helm chart using the following command:
 
 ```bash
-$ helm upgrade --install server-monitoring-stack server-monitoring-stack/server-monitoring-stack --reset-values --version 0.1.0-alpha.1 -n <your-server-namespace>
+$ helm upgrade --install server-monitoring-stack server-monitoring-stack/server-monitoring-stack --reset-values --version 0.1.0-alpha.2 -n <your-server-namespace>
 ```
 
 ### 5. Verify Prometheus Is Up and Targeting Telegraf

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,15 @@ prometheus:
     endpoints:
       - # -- Port name for the Prometheus client service.
         port: prometheus-client
+        # Default ServiceMonitor labels that are dropped since
+        # they overwrite app metric labels and are not useful
+        # as they always point to the server Telegraf instance.
+        relabelings:
+          - regex: (container|endpoint|namespace|pod|service)
+            action: labeldrop
+        metricRelabelings:
+          - regex: instance
+            action: labeldrop
   persistence:
     # -- Enable persistent storage for Prometheus.
     enabled: false


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-2071

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

They collide with the server app metric labels, overwriting them with Telegraf stuff

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

![Screenshot from 2025-03-24 08-58-40](https://github.com/user-attachments/assets/fb8a8f61-4f72-4944-8997-0d58b8a7b89e)

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
