### PR TITLE
Set Prometheus datasource for Grafana dashboards

### DIFF
--- a/templates/grafana/dashboards.yaml
+++ b/templates/grafana/dashboards.yaml
@@ -14,6 +14,9 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
   json: |
 {{ $.Files.Get $path | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Fixes issue with importing dashboards from another Grafana instance

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
