### PR TITLE
enable panel-title-description lint check for dashboards

### DIFF
--- a/dashboards/.lint
+++ b/dashboards/.lint
@@ -9,8 +9,6 @@ exclusions:
     entries:
     - dashboard: Server SLIs
     - dashboard: Tempo Monitoring
-  panel-title-description-rule:
-    reason: "Ideally each panel should have a description, but right now that's not the case."
   uneditable-dashboard:
     reason: "The dashboard needs to be editable in order to make copies of it."
     entries:


### PR DESCRIPTION
Now that all panels have descriptions (added in #81), remove the panel-title-description-rule exclusion so future dashboards are required to include panel descriptions.