### PR TITLE
Server 4.10: Update Server SLIs dashboard for OpenTelemetry collector metrics

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: server-monitoring-stack
 description: A reference Helm chart for setting up a monitoring stack for CircleCI server
-version: 0.1.0-alpha.12
+version: 0.1.0-alpha.13
 dependencies:
   - name: prometheus-operator-crds
     version: 19.0.0

--- a/README.md
+++ b/README.md
@@ -69,26 +69,16 @@ Expose port **9273** on the collector Service (e.g. name `prom-metrics`) so Prom
 
 | Server version | Dashboard in Grafana | `serverMetricsProfile` |
 | --- | --- | --- |
-| <=4.9 (Telegraf) | **Server SLIs** | `legacy` or `both` (default) |
-| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` or `both` (default) |
+| <=4.9 (Telegraf) | **Server SLIs** | `legacy` (default) |
+| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` |
 
-For **4.10+ / OTEL-only** installs, set the monitoring stack to provision only the OTEL dashboard:
+On **Server 4.10+**, set:
 
 ```yaml
 grafana:
   dashboards:
     serverMetricsProfile: server410
 ```
-
-Legacy Telegraf installs:
-
-```yaml
-grafana:
-  dashboards:
-    serverMetricsProfile: legacy
-```
-
-Default `both` ships **Server SLIs** and **Server SLIs (4.10+)** plus other JSON dashboards (e.g. Tempo). Use one SLI dashboard in Grafana matching your Server version.
 
 The 4.10+ dashboard omits five panels that had no matching OTEL series in testing (output receiver/internal/public non-2xx, step receiver/internal 5xx). They remain on the legacy **Server SLIs** dashboard for <=4.9.
 
@@ -286,7 +276,7 @@ Dashboards are provisioned directly from CRDs, which means any manual edits will
 | grafana.credentials.adminUser | string | `"admin"` | Grafana admin username. |
 | grafana.credentials.existingSecretName | string | `""` | Name of an existing secret for Grafana credentials. Leave empty to create a new secret. |
 | grafana.dashboards.jsonDirectory | string | `"dashboards"` | The directory containing JSON files for Grafana dashboards. |
-| grafana.dashboards.serverMetricsProfile | string | `"both"` | Which Server SLIs dashboard(s) to provision: `legacy` (Telegraf / <=4.9), `server410` (OTEL / 4.10+), or `both`. |
+| grafana.dashboards.serverMetricsProfile | string | `"legacy"` | Server SLIs dashboard to provision: `legacy` (Telegraf / <=4.9) or `server410` (OTEL / 4.10+). |
 | grafana.datasource.jsonData.timeInterval | string | `"5s"` | The time interval for Grafana to poll Prometheus. Specifies the frequency of data requests. |
 | grafana.enabled | string | `"-"` |  |
 | grafana.extraConfig | string | `""` | Add any custom Grafana configurations you require here. This should be a YAML-formatted string of additional settings for Grafana. |

--- a/README.md
+++ b/README.md
@@ -31,17 +31,31 @@ A reference Helm chart for setting up a monitoring stack for CircleCI server
 
 #### Metrics
 
-To set up monitoring for a CircleCI server instance, you need to configure Telegraf to set up a Prometheus client and expose a metrics endpoint. Add the following configuration to the CircleCI **server** Helm chart values:
+CircleCI Server **4.10+** exports metrics via **opentelemetry-collector** (StatsD receiver → Prometheus exporter on port **9273**). The Telegraf `prometheus_client` output is no longer deployed.
+
+Add the following to the CircleCI **server** Helm chart values (adjust processors to match your chart defaults):
 
 ```yaml
-telegraf:
+opentelemetry-collector:
   config:
-    outputs:
-      - file:
-          files: ["stdout"]
-      - prometheus_client:
-          listen: ":9273"
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9273
+    receivers:
+      statsd:
+        endpoint: 0.0.0.0:8125
+        is_monotonic_counter: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [statsd]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
 ```
+
+Expose port **9273** on the collector Service (e.g. name `prom-metrics`) so Prometheus can scrape `/metrics`. The reference chart ServiceMonitor expects that port.
+
+**Server ≤4.9:** configure Telegraf `prometheus_client` on `:9273` instead; the bundled **Server SLIs** dashboard targets OTEL metric names on 4.10+.
 
 #### Tracing
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ A reference Helm chart for setting up a monitoring stack for CircleCI server
 
 #### Metrics
 
-CircleCI Server **4.10+** exports metrics via **opentelemetry-collector** (StatsD receiver → Prometheus exporter on port **9273**). The Telegraf `prometheus_client` output is no longer deployed.
+**CircleCI Server <=4.9** — configure Telegraf `prometheus_client` on port **9273** in the CircleCI **server** Helm chart values:
 
-Add the following to the CircleCI **server** Helm chart values (adjust processors to match your chart defaults):
+```yaml
+telegraf:
+  config:
+    outputs:
+      - file:
+          files: ["stdout"]
+      - prometheus_client:
+          listen: ":9273"
+```
+
+**CircleCI Server 4.10+** — metrics are exported by **opentelemetry-collector** (StatsD receiver → Prometheus exporter on **9273**). Add or align with your chart defaults:
 
 ```yaml
 opentelemetry-collector:
@@ -55,7 +65,32 @@ opentelemetry-collector:
 
 Expose port **9273** on the collector Service (e.g. name `prom-metrics`) so Prometheus can scrape `/metrics`. The reference chart ServiceMonitor expects that port.
 
-**Server ≤4.9:** configure Telegraf `prometheus_client` on `:9273` instead; the bundled **Server SLIs** dashboard targets OTEL metric names on 4.10+.
+#### Grafana dashboards (this chart)
+
+| Server version | Dashboard in Grafana | `serverMetricsProfile` |
+| --- | --- | --- |
+| <=4.9 (Telegraf) | **Server SLIs** | `legacy` or `both` (default) |
+| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` or `both` (default) |
+
+For **4.10+ / OTEL-only** installs, set the monitoring stack to provision only the OTEL dashboard:
+
+```yaml
+grafana:
+  dashboards:
+    serverMetricsProfile: server410
+```
+
+Legacy Telegraf installs:
+
+```yaml
+grafana:
+  dashboards:
+    serverMetricsProfile: legacy
+```
+
+Default `both` ships **Server SLIs** and **Server SLIs (4.10+)** plus other JSON dashboards (e.g. Tempo). Use one SLI dashboard in Grafana matching your Server version.
+
+The 4.10+ dashboard omits five panels that had no matching OTEL series in testing (output receiver/internal/public non-2xx, step receiver/internal 5xx). They remain on the legacy **Server SLIs** dashboard for <=4.9.
 
 #### Tracing
 
@@ -230,7 +265,7 @@ Dashboards are provisioned directly from CRDs, which means any manual edits will
    - Select **Export** in the upper right corner and then **Export as JSON**.
    - **Ensure that `Export the dashboard to use in another instance` is toggled on.**
 4. **Update the JSON File**:
-   - Download the file and replace the `./dashboards/server-slis.json` file with the updated copy.
+   - Download the file and replace the matching file under `./dashboards/` (`server-slis.json` for <=4.9, `server-slis-server4.10.json` for 4.10+ OTEL).
    - Run the following command to automatically validate the JSON and apply necessary updates:
      ```bash
      ./do validate-dashboards
@@ -251,6 +286,7 @@ Dashboards are provisioned directly from CRDs, which means any manual edits will
 | grafana.credentials.adminUser | string | `"admin"` | Grafana admin username. |
 | grafana.credentials.existingSecretName | string | `""` | Name of an existing secret for Grafana credentials. Leave empty to create a new secret. |
 | grafana.dashboards.jsonDirectory | string | `"dashboards"` | The directory containing JSON files for Grafana dashboards. |
+| grafana.dashboards.serverMetricsProfile | string | `"both"` | Which Server SLIs dashboard(s) to provision: `legacy` (Telegraf / <=4.9), `server410` (OTEL / 4.10+), or `both`. |
 | grafana.datasource.jsonData.timeInterval | string | `"5s"` | The time interval for Grafana to poll Prometheus. Specifies the frequency of data requests. |
 | grafana.enabled | string | `"-"` |  |
 | grafana.extraConfig | string | `""` | Add any custom Grafana configurations you require here. This should be a YAML-formatted string of additional settings for Grafana. |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -25,7 +25,7 @@ This repository is currently under active development and is not yet a supported
 
 #### Metrics
 
-To set up monitoring for a CircleCI server instance, you need to configure Telegraf to set up a Prometheus client and expose a metrics endpoint. Add the following configuration to the CircleCI **server** Helm chart values:
+**CircleCI Server <=4.9** — configure Telegraf `prometheus_client` on port **9273** in the CircleCI **server** Helm chart values:
 
 ```yaml
 telegraf:
@@ -36,6 +36,53 @@ telegraf:
       - prometheus_client:
           listen: ":9273"
 ```
+
+**CircleCI Server 4.10+** — metrics are exported by **opentelemetry-collector** (StatsD receiver → Prometheus exporter on **9273**). Add or align with your chart defaults:
+
+```yaml
+opentelemetry-collector:
+  config:
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9273
+    receivers:
+      statsd:
+        endpoint: 0.0.0.0:8125
+        is_monotonic_counter: true
+    service:
+      pipelines:
+        metrics:
+          receivers: [statsd]
+          processors: [memory_limiter, batch]
+          exporters: [prometheus]
+```
+
+Expose port **9273** on the collector Service (e.g. name `prom-metrics`) so Prometheus can scrape `/metrics`. The reference chart ServiceMonitor expects that port.
+
+#### Grafana dashboards (this chart)
+
+| Server version | Dashboard in Grafana | `serverMetricsProfile` |
+| --- | --- | --- |
+| <=4.9 (Telegraf) | **Server SLIs** | `legacy` or `both` (default) |
+| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` or `both` (default) |
+
+For **4.10+ / OTEL-only** installs:
+
+```yaml
+grafana:
+  dashboards:
+    serverMetricsProfile: server410
+```
+
+Legacy Telegraf installs:
+
+```yaml
+grafana:
+  dashboards:
+    serverMetricsProfile: legacy
+```
+
+Default `both` ships both SLI dashboards. The 4.10+ file omits five output/step panels with no OTEL series observed in testing; they remain on the legacy dashboard.
 
 #### Tracing
 
@@ -210,7 +257,7 @@ Dashboards are provisioned directly from CRDs, which means any manual edits will
    - Select **Export** in the upper right corner and then **Export as JSON**.
    - **Ensure that `Export the dashboard to use in another instance` is toggled on.**
 4. **Update the JSON File**:
-   - Download the file and replace the `./dashboards/server-slis.json` file with the updated copy.
+   - Download the file and replace the matching file under `./dashboards/` (`server-slis.json` for <=4.9, `server-slis-server4.10.json` for 4.10+ OTEL).
    - Run the following command to automatically validate the JSON and apply necessary updates:
      ```bash
      ./do validate-dashboards

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -63,10 +63,10 @@ Expose port **9273** on the collector Service (e.g. name `prom-metrics`) so Prom
 
 | Server version | Dashboard in Grafana | `serverMetricsProfile` |
 | --- | --- | --- |
-| <=4.9 (Telegraf) | **Server SLIs** | `legacy` or `both` (default) |
-| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` or `both` (default) |
+| <=4.9 (Telegraf) | **Server SLIs** | `legacy` (default) |
+| 4.10+ (OTEL) | **Server SLIs (4.10+)** | `server410` |
 
-For **4.10+ / OTEL-only** installs:
+On **Server 4.10+**:
 
 ```yaml
 grafana:
@@ -74,15 +74,7 @@ grafana:
     serverMetricsProfile: server410
 ```
 
-Legacy Telegraf installs:
-
-```yaml
-grafana:
-  dashboards:
-    serverMetricsProfile: legacy
-```
-
-Default `both` ships both SLI dashboards. The 4.10+ file omits five output/step panels with no OTEL series observed in testing; they remain on the legacy dashboard.
+The 4.10+ file omits five output/step panels with no OTEL series observed in testing; they remain on the legacy dashboard.
 
 #### Tracing
 

--- a/dashboards/.lint
+++ b/dashboards/.lint
@@ -3,14 +3,17 @@ exclusions:
     reason: "The individual panels have a datasource."
     entries:
     - dashboard: Server SLIs
+    - dashboard: Server SLIs (4.10+)
     - dashboard: Tempo Monitoring
   panel-datasource-rule:
     reason: "'${DS_PROMETHEUS}' is a valid datasource."
     entries:
     - dashboard: Server SLIs
+    - dashboard: Server SLIs (4.10+)
     - dashboard: Tempo Monitoring
   uneditable-dashboard:
     reason: "The dashboard needs to be editable in order to make copies of it."
     entries:
     - dashboard: Server SLIs
+    - dashboard: Server SLIs (4.10+)
     - dashboard: Tempo Monitoring

--- a/dashboards/server-slis-server4.10.json
+++ b/dashboards/server-slis-server4.10.json
@@ -1,0 +1,2961 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Server 4.10+ SLIs (opentelemetry-collector / OTEL metric names). Omits five panels present on the legacy Telegraf dashboard: Output Receiver/Internal/Public non-2xx, Step Receiver/Internal 5xx (no matching OTEL series in testing). To edit, see [documentation](https://github.com/circleci-public/circleci-server-monitoring-reference?tab=readme-ov-file#modifying-or-adding-grafana-dashboards).\n",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Pipelines",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Milliseconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/pipelines\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "pipelines",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/error-pipelines\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "error pipelines",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Max latency of creating pipelines",
+      "type": "timeseries",
+      "description": "Peak response time for pipeline creation requests."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sort_desc(topk(10, sum by(route, method) (circle_http_request{api_version=\"v2\", status_class=\"5xx\"}))) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "API v2 5xx by method/route",
+      "type": "timeseries",
+      "description": "Top API v2 routes returning server errors (5xx) by method and route."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Workflows",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "job-end"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(messaging_message_type) (workflows_conductor_engine_handler_messages_timing)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Workflow Messages Handled by Type",
+      "type": "timeseries",
+      "description": "Volume of workflow engine messages processed by type."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success=\"true\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success!=\"true\"})",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Number of handled messages",
+      "type": "timeseries",
+      "description": "Workflow messages split by success and failure."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Orbs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(orb_service_process_config{service=\"orb-service\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(orb_service_resolve_orbs{service=\"orb-service\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Max latency of compiling config",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(max\\(max_over_time\\(orb_service_process_config{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
+            "renamePattern": "Max Successful Timing"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(max\\(max_over_time\\(orb_service_resolve_orbs{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
+            "renamePattern": "Max Failed Timing"
+          }
+        }
+      ],
+      "type": "timeseries",
+      "description": "Peak config compilation latency in orb-service by result."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Insights",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(route) (circle_http_request{route=~\"/api/v2/insights/.*\", status_class=\"5xx\", deploy_environment=~\"(production|canary)\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "5xx By Route",
+      "type": "timeseries",
+      "description": "Server errors (5xx) on Insights API endpoints by route."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Webhooks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(status, type) (grpc_response{service=\"webhook-service\", status!=\"ok\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Response errors",
+      "type": "timeseries",
+      "description": "Webhook service non-OK gRPC responses by status and type."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Notifications",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(type, success) (circle_workflow_notifications_message_processing)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "overall-process-count",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(success) (circle_workflow_notifications_email)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "email-processed",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Workflows-System",
+      "type": "timeseries",
+      "description": "Notification processing volume and email delivery counts by success."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "circle_legacy_notifier_pipeline_updated_event OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Pipelines-System IngestionError",
+      "type": "timeseries",
+      "description": "Pipeline notification event ingestion errors."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Permissions",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(action) (rate(circle_permissions_service_client_call{status!~\"(200|202|400|401|403)\"}[$__rate_interval])) OR on(action) vector(0) / sum by(action) (rate(circle_permissions_service_client_call{status!~\"(400|401|403)\"}[$__rate_interval])) OR on(action) vector(0)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Permission client calls error rate % by action excluding 4xx",
+      "type": "timeseries",
+      "description": "Server-side error rate for permission checks by action, excluding client errors (4xx)."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(route, method, status) (avg_over_time(circle_permissions_service_request{status!~\"2.*\"}[$__interval])) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "API Call Errors",
+      "type": "timeseries",
+      "description": "Non-success responses from the permissions API by route, method, and status."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(method, route, status) (circle_permissions_service_request{status!~\"(200|202|201)\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Failed API calls",
+      "type": "timeseries",
+      "description": "Count of non-success permission API calls by method, route, and status code."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 11,
+      "panels": [],
+      "title": "Domain",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max by(endpoint) (circle_github_rate_limit) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "GitHub Rate Limit Percentage",
+      "type": "timeseries",
+      "description": "Percentage of GitHub API calls hitting rate limits by endpoint."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 72
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg by(endpoint) (circle_domain_service_provider_request)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max by(endpoint) (circle_domain_service_provider_request)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Timing - Providers HTTP calls (Avg)",
+      "type": "timeseries",
+      "description": "Average and peak latency of outbound VCS provider API calls by endpoint."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Runners",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "dash": [
+                10,
+                10
+              ],
+              "fill": "dash"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 81
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "avg by(http_route, http_method) (circleci_runner_admin_handler{http_status_code=\"500\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Runner API - 500 HTTP Responses (Internal Server Errors)",
+      "type": "timeseries",
+      "description": "Internal server errors (500) from the Runner API by route and method."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 81
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"204\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Claim attempts (204s)",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"200\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Successful claims (200s)",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Runner Tasks - Claims (Linear Scale)",
+      "type": "timeseries",
+      "description": "Runner task claim attempt rate (204) vs successful claim rate (200)."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 89
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Execution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 90
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max by(executor) (max_over_time(circleci_distributor_task_complete_total{executor!=\"runner\"}[$__interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": " Task Queue Depth",
+      "type": "timeseries",
+      "description": "Pending tasks in the distributor queue by executor type."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 90
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(circleci_distributor_gauge_dispatcher_job_queue_jobs[$__interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(circleci_distributor_gauge_dispatcher_job_queue_tasks[$__interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "max(max_over_time(circleci_distributor_gauge_dispatcher_job_queue_keys[$__interval]))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "",
+          "hide": false,
+          "instant": false,
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": " Job Queue Depth",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(max\\(max_over_time\\(circleci_distributor_gauge_dispatcher_job_queue_keys.*)",
+            "renamePattern": "Max Job Queue Keys"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(max\\(max_over_time\\(circleci_distributor_gauge_dispatcher_job_queue_jobs.*)",
+            "renamePattern": "Max Job Queue Jobs"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(max\\(max_over_time\\(circleci_distributor_gauge_dispatcher_job_queue_tasks.*)",
+            "renamePattern": "Max Job Queue Tasks"
+          }
+        }
+      ],
+      "type": "timeseries",
+      "description": "Dispatcher job queue size by jobs, tasks, and keys."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 98
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"external\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Distributor External API Request Errors (5xx)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*)",
+            "renamePattern": "Distributor External API Errors"
+          }
+        }
+      ],
+      "type": "timeseries",
+      "description": "Server errors (5xx) on the distributor external API by route and method."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 98
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Distributor Internal API Request Errors (5xx)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "(.*)",
+            "renamePattern": "Distributor Internal API Errors"
+          }
+        }
+      ],
+      "type": "timeseries",
+      "description": "Server errors (5xx) on the distributor internal API by route and method."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 106
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(sub_class) (circleci_docker_provisioner_handler{backoff=\"true\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Back Pressure",
+      "type": "timeseries",
+      "description": "Docker provisioner jobs in backoff state by sub-class."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 106
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_machine_provisioner_handler{http_server_name!=\"admin\", mode=\"externalapi\", http_status_code!~\"2.*\", http_method!=\"OPTIONS\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Machine Provisioner External API Request Errors",
+      "type": "timeseries",
+      "description": "Non-success responses from the machine provisioner external API by route and method."
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 40,
+  "tags": [
+    "circleci",
+    "server"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Server SLIs (4.10+)",
+  "uid": "beg3u6ond4y410",
+  "version": 1,
+  "weekStart": ""
+}

--- a/dashboards/server-slis.json
+++ b/dashboards/server-slis.json
@@ -151,7 +151,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(backplane_ring_http_request_upper{service=\"builds-service\", route=\"/v1/pipelines\"}[$__interval]))",
+          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/pipelines\"}[$__interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -167,7 +167,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(backplane_ring_http_request_upper{service=\"builds-service\", route=\"/v1/error-pipelines\"}[$__interval]))",
+          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/error-pipelines\"}[$__interval]))",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -292,7 +292,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sort_desc(topk(10, sum by(route, method) (circle_http_request_count{api_version=\"v2\", status_class=\"5xx\"}))) OR on() vector(0)",
+          "expr": "sort_desc(topk(10, sum by(route, method) (circle_http_request{api_version=\"v2\", status_class=\"5xx\"}))) OR on() vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -435,7 +435,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(message_type) (workflows_conductor_engine_handler_messages_timing_count)",
+          "expr": "sum by(messaging_message_type) (workflows_conductor_engine_handler_messages_timing)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -538,7 +538,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(success, message_type) (workflows_conductor_engine_handler_messages_timing_count{success=\"true\"})",
+          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success=\"true\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -554,7 +554,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(success, message_type) (workflows_conductor_engine_handler_messages_timing_count{success!=\"true\"})",
+          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success!=\"true\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -667,7 +667,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(orb_service_grpc_request_upper{service=\"orb-service\", result=\"success\"})",
+          "expr": "max(max_over_time(orb_service_process_config{service=\"orb-service\"}[$__interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -683,7 +683,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(orb_service_grpc_request_upper{service=\"orb-service\", result!=\"success\"})",
+          "expr": "max(max_over_time(orb_service_resolve_orbs{service=\"orb-service\"}[$__interval]))",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -699,14 +699,14 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(max\\(orb_service_grpc_request_upper{service=\"orb-service\", result=\"success\"}\\))",
+            "regex": "(max\\(max_over_time\\(orb_service_process_config{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
             "renamePattern": "Max Successful Timing"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(max\\(orb_service_grpc_request_upper{service=\"orb-service\", result!=\"success\"}\\))",
+            "regex": "(max\\(max_over_time\\(orb_service_resolve_orbs{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
             "renamePattern": "Max Failed Timing"
           }
         }
@@ -836,7 +836,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(route) (circle_http_request_count{route=~\"/api/v2/insights/.*\", status_class=\"5xx\", deploy_environment=~\"(production|canary)\"}) OR on() vector(0)",
+          "expr": "sum by(route) (circle_http_request{route=~\"/api/v2/insights/.*\", status_class=\"5xx\", deploy_environment=~\"(production|canary)\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -972,7 +972,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(status, type) (grpc_response_count{service=\"webhook-service\", status!=\"ok\"}) OR on() vector(0)",
+          "expr": "sum by(status, type) (grpc_response{service=\"webhook-service\", status!=\"ok\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1087,7 +1087,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(type, success) (circle_workflow_notifications_message_processing_count)",
+          "expr": "sum by(type, success) (circle_workflow_notifications_message_processing)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1103,7 +1103,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(success) (circle_workflow_notifications_email_count)",
+          "expr": "sum by(success) (circle_workflow_notifications_email)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1227,7 +1227,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "circle_backend_build_notify_pipelines_event_ingestion_error_error OR on() vector(0)",
+          "expr": "circle_legacy_notifier_pipeline_updated_event OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1359,7 +1359,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(action) (rate(circle_permissions_service_client_call_count{status!~\"(200|202|400|401|403)\"}[$__rate_interval])) OR on(action) vector(0) / sum by(action) (rate(circle_permissions_service_client_call_count{status!~\"(400|401|403)\"}[$__rate_interval])) OR on(action) vector(0)",
+          "expr": "sum by(action) (rate(circle_permissions_service_client_call{status!~\"(200|202|400|401|403)\"}[$__rate_interval])) OR on(action) vector(0) / sum by(action) (rate(circle_permissions_service_client_call{status!~\"(400|401|403)\"}[$__rate_interval])) OR on(action) vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1484,7 +1484,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(route, method, status) (avg_over_time(circle_permissions_service_request_count{status!~\"2.*\"}[$__interval])) OR on() vector(0)",
+          "expr": "sum by(route, method, status) (avg_over_time(circle_permissions_service_request{status!~\"2.*\"}[$__interval])) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1607,7 +1607,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(method, route, status) (circle_permissions_service_request_count{status!~\"(200|202|201)\"}) OR on() vector(0)",
+          "expr": "sum by(method, route, status) (circle_permissions_service_request{status!~\"(200|202|201)\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1743,7 +1743,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(provider_name, endpoint) (circle_domain_service_providers_rate_limit{provider_name=\"github\"}) / sum by(provider_name, endpoint) (circle_domain_service_provider_request_count{provider_name=\"github\"}) OR on() vector(0)",
+          "expr": "max by(endpoint) (circle_github_rate_limit) OR on() vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1867,7 +1867,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg by(endpoint) (circle_domain_service_provider_request_mean)",
+          "expr": "avg by(endpoint) (circle_domain_service_provider_request)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1883,7 +1883,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max by(endpoint) (circle_domain_service_provider_request_upper)",
+          "expr": "max by(endpoint) (circle_domain_service_provider_request)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2027,7 +2027,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg by(http_route, http_method) (circleci_runner_admin_handler_count{http_status_code=\"500\"}) OR on() vector(0)",
+          "expr": "avg by(http_route, http_method) (circleci_runner_admin_handler{http_status_code=\"500\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2129,7 +2129,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(circleci_runner_admin_handler_count{http_route=~\".*/claim\", http_status_code=\"204\"}[$__rate_interval])",
+          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"204\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2145,7 +2145,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(circleci_runner_admin_handler_count{http_route=~\".*/claim\", http_status_code=\"200\"}[$__rate_interval])",
+          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"200\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2261,7 +2261,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max by(executor) (max_over_time(circleci_distributor_task_counts{executor!=\"runner\"}[$__interval]))",
+          "expr": "max by(executor) (max_over_time(circleci_distributor_task_complete_total{executor!=\"runner\"}[$__interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2546,7 +2546,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler_count{http_server_name!=\"admin\", mode=\"external\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"external\", http_status_code=~\"5.*\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2669,7 +2669,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler_count{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2801,7 +2801,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(sub_class) (circleci_docker_provisioner_job_count{backoff=\"true\"}) OR on() vector(0)",
+          "expr": "sum by(sub_class) (circleci_docker_provisioner_handler{backoff=\"true\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2924,7 +2924,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_machine_provisioner_handler_count{http_server_name!=\"admin\", mode=\"externalapi\", http_status_code!~\"2.*\", http_method!=\"OPTIONS\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_machine_provisioner_handler{http_server_name!=\"admin\", mode=\"externalapi\", http_status_code!~\"2.*\", http_method!=\"OPTIONS\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2937,647 +2937,6 @@
       "title": "Machine Provisioner External API Request Errors",
       "type": "timeseries",
       "description": "Non-success responses from the machine provisioner external API by route and method."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsZero",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 114
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"receiver\", http_status_code!~\"2.*\"})",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Output Receiver Handled Requests (non 2xx)",
-      "type": "timeseries",
-      "description": "Non-success responses from the output service receiver by route and status."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsZero",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 114
-      },
-      "id": 36,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"internal\", http_status_code!~\"2.*\"}) OR on() vector(0)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Output Internal Handled Requests (non 2xx)",
-      "type": "timeseries",
-      "description": "Non-success responses from the output service internal API by route and status."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsZero",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 122
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"public\", http_route!=\"/ready\", http_status_code!~\"2.*\", http_status_code!=\"307\"}) OR on() vector(0)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Output Public Handled Requests (non 2xx, 3xx)",
-      "type": "timeseries",
-      "description": "Non-success responses from the output service public API, excluding redirects."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsZero",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 122
-      },
-      "id": 38,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"receiver\", http_status_code=~\"5.*\"}) OR on() vector(0)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"receiver\", http_status_code=~\"4.*\"}) OR vector(0)",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        }
-      ],
-      "title": "Step Receiver API Request Errors (5xx)",
-      "transformations": [
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "{http_method=\"POST\", http_route=\"/api/v2/step/output\", http_status_code=\"499\", version=\"1.0.9757-d437933\"}",
-            "renamePattern": ""
-          }
-        }
-      ],
-      "type": "timeseries",
-      "description": "Server errors (5xx) and client errors (4xx) from the step service receiver by route and method."
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "bars",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byValue",
-              "options": {
-                "op": "gte",
-                "reducer": "allIsZero",
-                "value": 0
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": true,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 130
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "11.5.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\", http_method!=\"options\"}) OR on() vector(0)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "Step Internal API Request Errors (5xx)",
-      "type": "timeseries",
-      "description": "Server errors (5xx) from the step service internal API by route and method."
     }
   ],
   "refresh": "",

--- a/dashboards/server-slis.json
+++ b/dashboards/server-slis.json
@@ -151,7 +151,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/pipelines\"}[$__interval]))",
+          "expr": "max(max_over_time(backplane_ring_http_request_upper{service=\"builds-service\", route=\"/v1/pipelines\"}[$__interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -167,7 +167,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(backplane_ring_http_request{service=\"builds-service\", route=\"/v1/error-pipelines\"}[$__interval]))",
+          "expr": "max(max_over_time(backplane_ring_http_request_upper{service=\"builds-service\", route=\"/v1/error-pipelines\"}[$__interval]))",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -292,7 +292,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sort_desc(topk(10, sum by(route, method) (circle_http_request{api_version=\"v2\", status_class=\"5xx\"}))) OR on() vector(0)",
+          "expr": "sort_desc(topk(10, sum by(route, method) (circle_http_request_count{api_version=\"v2\", status_class=\"5xx\"}))) OR on() vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -435,7 +435,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(messaging_message_type) (workflows_conductor_engine_handler_messages_timing)",
+          "expr": "sum by(message_type) (workflows_conductor_engine_handler_messages_timing_count)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -538,7 +538,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success=\"true\"})",
+          "expr": "sum by(success, message_type) (workflows_conductor_engine_handler_messages_timing_count{success=\"true\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -554,7 +554,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(rabbitmq_handle_success, messaging_message_type) (workflows_conductor_engine_handler_messages_timing{rabbitmq_handle_success!=\"true\"})",
+          "expr": "sum by(success, message_type) (workflows_conductor_engine_handler_messages_timing_count{success!=\"true\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -667,7 +667,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(orb_service_process_config{service=\"orb-service\"}[$__interval]))",
+          "expr": "max(orb_service_grpc_request_upper{service=\"orb-service\", result=\"success\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -683,7 +683,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max(max_over_time(orb_service_resolve_orbs{service=\"orb-service\"}[$__interval]))",
+          "expr": "max(orb_service_grpc_request_upper{service=\"orb-service\", result!=\"success\"})",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -699,14 +699,14 @@
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(max\\(max_over_time\\(orb_service_process_config{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
+            "regex": "(max\\(orb_service_grpc_request_upper{service=\"orb-service\", result=\"success\"}\\))",
             "renamePattern": "Max Successful Timing"
           }
         },
         {
           "id": "renameByRegex",
           "options": {
-            "regex": "(max\\(max_over_time\\(orb_service_resolve_orbs{service=\"orb-service\"}\\[\\$__interval\\]\\)\\))",
+            "regex": "(max\\(orb_service_grpc_request_upper{service=\"orb-service\", result!=\"success\"}\\))",
             "renamePattern": "Max Failed Timing"
           }
         }
@@ -836,7 +836,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(route) (circle_http_request{route=~\"/api/v2/insights/.*\", status_class=\"5xx\", deploy_environment=~\"(production|canary)\"}) OR on() vector(0)",
+          "expr": "sum by(route) (circle_http_request_count{route=~\"/api/v2/insights/.*\", status_class=\"5xx\", deploy_environment=~\"(production|canary)\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -972,7 +972,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(status, type) (grpc_response{service=\"webhook-service\", status!=\"ok\"}) OR on() vector(0)",
+          "expr": "sum by(status, type) (grpc_response_count{service=\"webhook-service\", status!=\"ok\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1087,7 +1087,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(type, success) (circle_workflow_notifications_message_processing)",
+          "expr": "sum by(type, success) (circle_workflow_notifications_message_processing_count)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1103,7 +1103,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(success) (circle_workflow_notifications_email)",
+          "expr": "sum by(success) (circle_workflow_notifications_email_count)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1227,7 +1227,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "circle_legacy_notifier_pipeline_updated_event OR on() vector(0)",
+          "expr": "circle_backend_build_notify_pipelines_event_ingestion_error_error OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1359,7 +1359,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(action) (rate(circle_permissions_service_client_call{status!~\"(200|202|400|401|403)\"}[$__rate_interval])) OR on(action) vector(0) / sum by(action) (rate(circle_permissions_service_client_call{status!~\"(400|401|403)\"}[$__rate_interval])) OR on(action) vector(0)",
+          "expr": "sum by(action) (rate(circle_permissions_service_client_call_count{status!~\"(200|202|400|401|403)\"}[$__rate_interval])) OR on(action) vector(0) / sum by(action) (rate(circle_permissions_service_client_call_count{status!~\"(400|401|403)\"}[$__rate_interval])) OR on(action) vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1484,7 +1484,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(route, method, status) (avg_over_time(circle_permissions_service_request{status!~\"2.*\"}[$__interval])) OR on() vector(0)",
+          "expr": "sum by(route, method, status) (avg_over_time(circle_permissions_service_request_count{status!~\"2.*\"}[$__interval])) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1607,7 +1607,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(method, route, status) (circle_permissions_service_request{status!~\"(200|202|201)\"}) OR on() vector(0)",
+          "expr": "sum by(method, route, status) (circle_permissions_service_request_count{status!~\"(200|202|201)\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1743,7 +1743,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max by(endpoint) (circle_github_rate_limit) OR on() vector(0)",
+          "expr": "sum by(provider_name, endpoint) (circle_domain_service_providers_rate_limit{provider_name=\"github\"}) / sum by(provider_name, endpoint) (circle_domain_service_provider_request_count{provider_name=\"github\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -1867,7 +1867,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg by(endpoint) (circle_domain_service_provider_request)",
+          "expr": "avg by(endpoint) (circle_domain_service_provider_request_mean)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -1883,7 +1883,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max by(endpoint) (circle_domain_service_provider_request)",
+          "expr": "max by(endpoint) (circle_domain_service_provider_request_upper)",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2027,7 +2027,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "avg by(http_route, http_method) (circleci_runner_admin_handler{http_status_code=\"500\"}) OR on() vector(0)",
+          "expr": "avg by(http_route, http_method) (circleci_runner_admin_handler_count{http_status_code=\"500\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2129,7 +2129,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"204\"}[$__rate_interval])",
+          "expr": "rate(circleci_runner_admin_handler_count{http_route=~\".*/claim\", http_status_code=\"204\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2145,7 +2145,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(circleci_runner_admin_handler{http_route=~\".*/claim\", http_status_code=\"200\"}[$__rate_interval])",
+          "expr": "rate(circleci_runner_admin_handler_count{http_route=~\".*/claim\", http_status_code=\"200\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": true,
@@ -2261,7 +2261,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "max by(executor) (max_over_time(circleci_distributor_task_complete_total{executor!=\"runner\"}[$__interval]))",
+          "expr": "max by(executor) (max_over_time(circleci_distributor_task_counts{executor!=\"runner\"}[$__interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2546,7 +2546,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"external\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler_count{http_server_name!=\"admin\", mode=\"external\", http_status_code=~\"5.*\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2669,7 +2669,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_distributor_handler_count{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2801,7 +2801,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(sub_class) (circleci_docker_provisioner_handler{backoff=\"true\"}) OR on() vector(0)",
+          "expr": "sum by(sub_class) (circleci_docker_provisioner_job_count{backoff=\"true\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2924,7 +2924,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_machine_provisioner_handler{http_server_name!=\"admin\", mode=\"externalapi\", http_status_code!~\"2.*\", http_method!=\"OPTIONS\"}) OR on() vector(0)",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_machine_provisioner_handler_count{http_server_name!=\"admin\", mode=\"externalapi\", http_status_code!~\"2.*\", http_method!=\"OPTIONS\"}) OR on() vector(0)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -2937,6 +2937,647 @@
       "title": "Machine Provisioner External API Request Errors",
       "type": "timeseries",
       "description": "Non-success responses from the machine provisioner external API by route and method."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 114
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"receiver\", http_status_code!~\"2.*\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Output Receiver Handled Requests (non 2xx)",
+      "type": "timeseries",
+      "description": "Non-success responses from the output service receiver by route and status."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 114
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"internal\", http_status_code!~\"2.*\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Output Internal Handled Requests (non 2xx)",
+      "type": "timeseries",
+      "description": "Non-success responses from the output service internal API by route and status."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 122
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(http_route, http_status_code, http_method, version) (circleci_output_handler_count{mode=\"public\", http_route!=\"/ready\", http_status_code!~\"2.*\", http_status_code!=\"307\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Output Public Handled Requests (non 2xx, 3xx)",
+      "type": "timeseries",
+      "description": "Non-success responses from the output service public API, excluding redirects."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 122
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"receiver\", http_status_code=~\"5.*\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"receiver\", http_status_code=~\"4.*\"}) OR vector(0)",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Step Receiver API Request Errors (5xx)",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "{http_method=\"POST\", http_route=\"/api/v2/step/output\", http_status_code=\"499\", version=\"1.0.9757-d437933\"}",
+            "renamePattern": ""
+          }
+        }
+      ],
+      "type": "timeseries",
+      "description": "Server errors (5xx) and client errors (4xx) from the step service receiver by route and method."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 130
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "sum by(http_route, http_method, http_status_code, version) (circleci_step_handler_count{http_server_name!=\"admin\", mode=\"internal\", http_status_code=~\"5.*\", http_method!=\"options\"}) OR on() vector(0)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Step Internal API Request Errors (5xx)",
+      "type": "timeseries",
+      "description": "Server errors (5xx) from the step service internal API by route and method."
     }
   ],
   "refresh": "",

--- a/scripts/validate_dashboards.sh
+++ b/scripts/validate_dashboards.sh
@@ -1,32 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-file_path="./dashboards/server-slis.json"
-
 check_exported_for_external_instance() {
+    local file_path="$1"
     if jq '.__inputs[] | select(.name == "DS_PROMETHEUS")' "$file_path" > /dev/null; then
-        echo "__input 'DS_PROMETHEUS' is configured correctly."
+        echo "__input 'DS_PROMETHEUS' is configured correctly in ${file_path}."
     else
-        echo "Error: '__input DS_PROMETHEUS' is missing. Ensure the dashboard is exported for an external instance."
+        echo "Error: '__input DS_PROMETHEUS' is missing in ${file_path}. Ensure the dashboard is exported for an external instance."
         exit 1
     fi
 }
 
 check_title_and_uid() {
-    jq --arg title "Server SLIs" --arg uid "beg3u6ond4ydcb" '
+    local file_path="$1"
+    local expected_title="$2"
+    local expected_uid="$3"
+
+    jq --arg title "$expected_title" --arg uid "$expected_uid" '
         .title = $title |
         .uid = $uid
     ' "$file_path" > "${file_path}.tmp"
 
     if ! diff -q "$file_path" "${file_path}.tmp" > /dev/null; then
         mv "${file_path}.tmp" "$file_path"
-        echo "Dashboard updated: title or UID was incorrect. Please commit the changes."
+        echo "Dashboard updated in ${file_path}: title or UID was incorrect. Please commit the changes."
         exit 1
     else
         rm "${file_path}.tmp"
-        echo "Dashboard title and UID are correctly set."
+        echo "Dashboard title and UID are correctly set in ${file_path}."
     fi
 }
 
-check_exported_for_external_instance
-check_title_and_uid
+validate_dashboard() {
+    local file_path="$1"
+    local expected_title="$2"
+    local expected_uid="$3"
+    check_exported_for_external_instance "$file_path"
+    check_title_and_uid "$file_path" "$expected_title" "$expected_uid"
+}
+
+validate_dashboard "./dashboards/server-slis.json" "Server SLIs" "beg3u6ond4ydcb"
+validate_dashboard "./dashboards/server-slis-server4.10.json" "Server SLIs (4.10+)" "beg3u6ond4y410"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -48,16 +48,14 @@ Compute if tempo is enabled.
 
 {{/*
 Return whether a dashboard JSON path should be provisioned for serverMetricsProfile.
-Profile legacy: Telegraf-era Server SLIs only. server410: OTEL 4.10+ SLIs only. both: all dashboards.
+Profile legacy (default): Telegraf-era Server SLIs. server410: OTEL 4.10+ SLIs.
 */}}
 {{- define "grafana.dashboard.include" -}}
-{{- $profile := .profile | default "both" -}}
+{{- $profile := .profile | default "legacy" -}}
 {{- $base := base .path -}}
 {{- $isServer410 := contains "server4.10" $base -}}
 {{- $isServerSlis := hasPrefix "server-slis" $base -}}
-{{- if eq $profile "both" -}}
-true
-{{- else if eq $profile "legacy" -}}
+{{- if eq $profile "legacy" -}}
 {{- if $isServer410 -}}false{{- else -}}true{{- end -}}
 {{- else if eq $profile "server410" -}}
 {{- if $isServer410 -}}true{{- else if $isServerSlis -}}false{{- else -}}true{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -45,3 +45,23 @@ Compute if tempo is enabled.
   (eq (.Values.tempo.enabled | toString) "true")
   (and (eq (.Values.tempo.enabled | toString) "-") (eq (.Values.global.enabled | toString) "true"))) -}}
 {{- end -}}
+
+{{/*
+Return whether a dashboard JSON path should be provisioned for serverMetricsProfile.
+Profile legacy: Telegraf-era Server SLIs only. server410: OTEL 4.10+ SLIs only. both: all dashboards.
+*/}}
+{{- define "grafana.dashboard.include" -}}
+{{- $profile := .profile | default "both" -}}
+{{- $base := base .path -}}
+{{- $isServer410 := contains "server4.10" $base -}}
+{{- $isServerSlis := hasPrefix "server-slis" $base -}}
+{{- if eq $profile "both" -}}
+true
+{{- else if eq $profile "legacy" -}}
+{{- if $isServer410 -}}false{{- else -}}true{{- end -}}
+{{- else if eq $profile "server410" -}}
+{{- if $isServer410 -}}true{{- else if $isServerSlis -}}false{{- else -}}true{{- end -}}
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/templates/grafana/dashboards.yaml
+++ b/templates/grafana/dashboards.yaml
@@ -2,7 +2,9 @@
 {{- if .grafanaEnabled }}
 
 {{- $jsonDir := .Values.grafana.dashboards.jsonDirectory -}}
+{{- $profile := .Values.grafana.dashboards.serverMetricsProfile | default "both" -}}
 {{- range $path, $_ := .Files.Glob (printf "%s/*.json" $jsonDir) }}
+{{- if eq (include "grafana.dashboard.include" (dict "path" $path "profile" $profile)) "true" }}
 {{- $dashboardFileName := (base $path) }}
 {{- $dashboardName := (trimSuffix ".json" $dashboardFileName | lower ) }}
 ---
@@ -19,6 +21,7 @@ spec:
       datasourceName: "Prometheus"
   json: |
 {{ $.Files.Get $path | nindent 4 }}
+{{- end }}
 {{- end }}
 
 {{- end }}

--- a/templates/grafana/dashboards.yaml
+++ b/templates/grafana/dashboards.yaml
@@ -2,7 +2,7 @@
 {{- if .grafanaEnabled }}
 
 {{- $jsonDir := .Values.grafana.dashboards.jsonDirectory -}}
-{{- $profile := .Values.grafana.dashboards.serverMetricsProfile | default "both" -}}
+{{- $profile := .Values.grafana.dashboards.serverMetricsProfile | default "legacy" -}}
 {{- range $path, $_ := .Files.Glob (printf "%s/*.json" $jsonDir) }}
 {{- if eq (include "grafana.dashboard.include" (dict "path" $path "profile" $profile)) "true" }}
 {{- $dashboardFileName := (base $path) }}

--- a/tests/grafana/dashboards_test.yaml
+++ b/tests/grafana/dashboards_test.yaml
@@ -3,33 +3,20 @@ templates:
   - grafana/dashboards.yaml
 
 tests:
-  - it: should create all dashboards when serverMetricsProfile is both
+  - it: should provision legacy SLIs by default when serverMetricsProfile is unset
     set:
       grafana.dashboards.jsonDirectory: dashboards
-      grafana.dashboards.serverMetricsProfile: both
     asserts:
       - hasDocuments:
-          count: 3
+          count: 2
       - equal:
           path: metadata.name
           value: server-slis
         documentSelector:
           path: metadata.name
           value: server-slis
-      - equal:
-          path: metadata.name
-          value: server-slis-server4.10
-        documentSelector:
-          path: metadata.name
-          value: server-slis-server4.10
-      - matchRegex:
-          path: spec.json
-          pattern: '"title":\s*"Server SLIs \(4\.10\+\)"'
-        documentSelector:
-          path: metadata.name
-          value: server-slis-server4.10
 
-  - it: should provision legacy SLIs only when serverMetricsProfile is legacy
+  - it: should provision legacy SLIs when serverMetricsProfile is legacy
     set:
       grafana.dashboards.jsonDirectory: dashboards
       grafana.dashboards.serverMetricsProfile: legacy

--- a/tests/grafana/dashboards_test.yaml
+++ b/tests/grafana/dashboards_test.yaml
@@ -3,22 +3,56 @@ templates:
   - grafana/dashboards.yaml
 
 tests:
-  - it: should create grafana dashboards
+  - it: should create all dashboards when serverMetricsProfile is both
     set:
       grafana.dashboards.jsonDirectory: dashboards
+      grafana.dashboards.serverMetricsProfile: both
     asserts:
-      - isKind:
-          of: GrafanaDashboard
-        documentIndex: 0
+      - hasDocuments:
+          count: 3
       - equal:
           path: metadata.name
           value: server-slis
-        documentIndex: 0
+        documentSelector:
+          path: metadata.name
+          value: server-slis
       - equal:
-          path: spec.instanceSelector.matchLabels.dashboards
-          value: grafana
-        documentIndex: 0
+          path: metadata.name
+          value: server-slis-server4.10
+        documentSelector:
+          path: metadata.name
+          value: server-slis-server4.10
       - matchRegex:
           path: spec.json
-          pattern: '"title":\s*"Max latency of creating pipelines"'
-        documentIndex: 0
+          pattern: '"title":\s*"Server SLIs \(4\.10\+\)"'
+        documentSelector:
+          path: metadata.name
+          value: server-slis-server4.10
+
+  - it: should provision legacy SLIs only when serverMetricsProfile is legacy
+    set:
+      grafana.dashboards.jsonDirectory: dashboards
+      grafana.dashboards.serverMetricsProfile: legacy
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: server-slis
+        documentSelector:
+          path: metadata.name
+          value: server-slis
+
+  - it: should provision 4.10 SLIs only when serverMetricsProfile is server410
+    set:
+      grafana.dashboards.jsonDirectory: dashboards
+      grafana.dashboards.serverMetricsProfile: server410
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: server-slis-server4.10
+        documentSelector:
+          path: metadata.name
+          value: server-slis-server4.10

--- a/values.yaml
+++ b/values.yaml
@@ -149,10 +149,9 @@ grafana:
   dashboards:
     # -- The directory containing JSON files for Grafana dashboards.
     jsonDirectory: dashboards
-    # -- Which Server SLIs dashboard(s) to provision. Use `server410` on CircleCI Server
-    # 4.10+ (opentelemetry-collector metrics). Use `legacy` on Server <=4.9 (Telegraf).
-    # `both` ships both SLI dashboards (default); pick one in Grafana if both are present.
-    serverMetricsProfile: both
+    # -- Which Server SLIs dashboard to provision. Default `legacy` (Telegraf / Server <=4.9).
+    # Set `server410` on CircleCI Server 4.10+ (opentelemetry-collector metrics).
+    serverMetricsProfile: legacy
 
 tempo:
   # -- Enable Tempo distributed tracing

--- a/values.yaml
+++ b/values.yaml
@@ -149,6 +149,10 @@ grafana:
   dashboards:
     # -- The directory containing JSON files for Grafana dashboards.
     jsonDirectory: dashboards
+    # -- Which Server SLIs dashboard(s) to provision. Use `server410` on CircleCI Server
+    # 4.10+ (opentelemetry-collector metrics). Use `legacy` on Server <=4.9 (Telegraf).
+    # `both` ships both SLI dashboards (default); pick one in Grafana if both are present.
+    serverMetricsProfile: both
 
 tempo:
   # -- Enable Tempo distributed tracing


### PR DESCRIPTION
## Summary

Adds a **4.10+ OTEL** copy of the Server SLIs dashboard ([`dashboards/server-slis-server4.10.json`](dashboards/server-slis-server4.10.json), Grafana title **Server SLIs (4.10+)**) and leaves the existing Telegraf dashboard ([`dashboards/server-slis.json`](dashboards/server-slis.json)) unchanged for Server <=4.9.

Addresses Atul’s feedback: no in-place breaking change; filename matches `*-server4.10-*`.

Fixes **No data** on 4.10 when customers use the wrong SLI dashboard or OTEL metric names.

**Jira:** [ONPREM-3386](https://circleci.atlassian.net/browse/ONPREM-3386)

---

## Monitoring stack values (4.10+ / OTEL customers)

Provision only the OTEL SLI dashboard (recommended on Server 4.10+):

```yaml
grafana:
  dashboards:
    serverMetricsProfile: server410
```

Default is `both` (legacy + 4.10+ SLIs + Tempo). Telegraf installs can use `legacy`.

---

## What changed in Server 4.10 (why)

| Before (<=4.9) | After (4.10+) |
| --- | --- |
| **Telegraf** `prometheus_client` on `:9273` | **opentelemetry-collector** Prometheus exporter on `:9273` |
| Prometheus names often use Telegraf suffixes (`*_count`, `*_mean`, `*_upper`) | OTEL exporter uses **base names** |
| Some SLIs use one metric + labels (e.g. `orb_service_grpc_request_upper{result=}`) | Some SLIs **split** across metrics or **rename labels** |

Applications still emit **StatsD**; only the collector/exporter changed.

---

## Dashboard changes (`server-slis-server4.10.json` only)

### Metric renames (Telegraf → OTEL)

- `*_count` → base counter names (`circle_http_request`, `circleci_*_handler`, `grpc_response`, etc.)
- `backplane_ring_http_request_upper` → `backplane_ring_http_request`
- `circleci_distributor_task_counts` → `circleci_distributor_task_complete_total`
- `circleci_docker_provisioner_job_count` → `circleci_docker_provisioner_handler`

### Label / expression updates

- Workflows conductor: `success` / `message_type` → `rabbitmq_handle_success` / `messaging_message_type`
- GitHub rate limit panel → `max by(endpoint) (circle_github_rate_limit)`
- Domain provider timing → `circle_domain_service_provider_request`
- Pipeline ingestion errors → `circle_legacy_notifier_pipeline_updated_event`

### Orb service (non-obvious)

OTEL (4.10):

```promql
max(max_over_time(orb_service_process_config{service="orb-service"}[$__interval]))
max(max_over_time(orb_service_resolve_orbs{service="orb-service"}[$__interval]))
```

### Panels removed on 4.10+ dashboard only (not on legacy `server-slis.json`)

These five panels remain on the **legacy** dashboard for <=4.9 Telegraf installs. They were **omitted** from **Server SLIs (4.10+)** because no matching OTEL series were observed in testing on a private 4.10 install:

| Panel | Legacy Telegraf-oriented intent |
| --- | --- |
| Output Receiver Handled Requests (non 2xx) | Output receiver non-2xx handling |
| Output Internal Handled Requests (non 2xx) | Output internal non-2xx |
| Output Public Handled Requests (non 2xx, 3xx) | Output public non-2xx/3xx |
| Step Receiver API Request Errors (5xx) | Step receiver 5xx |
| Step Internal API Request Errors (5xx) | Step internal API 5xx |

Please confirm with component teams whether output/step handlers still emit StatsD on 4.10 and which OTEL metric names apply; we can restore panels on the 4.10+ dashboard when documented.

### Panels that may still be empty on quiet installs

Valid PromQL but no matching series without error traffic (e.g. API v2 5xx, distributor 5xx)—not a dashboard bug.

---

## README

Documents Telegraf (<=4.9) and OTEL (4.10+) Server metrics setup, dashboard selection, and `serverMetricsProfile`.

---

## Testing

- `./do validate-dashboards`, `./do unit-tests`
- Validated OTEL PromQL on a private CircleCI Server 4.10 install (BYO Prometheus/Grafana)

---

## Checklist

- [ ] On-Prem review of dropped output/step panels on 4.10+ dashboard
- [x] Chart version bump (`0.1.0-alpha.13`)

[ONPREM-3386]: https://circleci.atlassian.net/browse/ONPREM-3386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
